### PR TITLE
drivers: roc1_android: Do not export PVRSRV_NEED_PVR_DPF

### DIFF
--- a/drivers/modules/kernel4.14/gpu/rogue/driver/build/linux/roc1_android/Android.mk
+++ b/drivers/modules/kernel4.14/gpu/rogue/driver/build/linux/roc1_android/Android.mk
@@ -31,11 +31,9 @@ $(warning MALI_PLATFORM_NAME: $(MALI_PLATFORM_NAME))
 
 ifeq ($(TARGET_BUILD_VARIANT),user)
   BUILD_ := release
-  export PVRSRV_NEED_PVR_DPF := 1
 else
 #  BUILD_ := debug
   BUILD_ := release
-  export PVRSRV_NEED_PVR_DPF := 1
 endif
 
 BUILD_ := release


### PR DESCRIPTION
Fixes:

kernel/realme/RMX3261/drivers/modules/kernel4.14/gpu/rogue/driver/build/linux/roc1_android/Android.mk:38: error: PVRSRV_NEED_PVR_DPF: export is obsolete. It is a global setting. See https://android.googlesource.com/platform/build/+/master/Changes.md#export_keyword.